### PR TITLE
Return with exit code 1 on failure.

### DIFF
--- a/syntax
+++ b/syntax
@@ -50,6 +50,12 @@ if (!$path) {
 }
 
 $syntax = new Syntax();
-$syntax->run($path, $stdio);
+$success = $syntax->run($path, $stdio);
+
+if ($success) {
+    exit(0);
+} else {
+    exit(1);
+}
 
 ?>


### PR DESCRIPTION
@agentile I still had this uncommitted.  This change ensures that syntax returns exit code 1 on PHP 5.5.x.
