### PR TITLE
Allow the php interpreter to be overridden

### DIFF
--- a/syntax
+++ b/syntax
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 /**
 * FollowUpBoss: Real Estate Lead Management Software.

--- a/use-check
+++ b/use-check
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 /**
 * FollowUpBoss: Real Estate Lead Management Software.


### PR DESCRIPTION
In MacOS using homebrew, php is installed in a different location than the system php (/usr/bin/php). It is desired to use a different php in order to select the same version and install pecl extensions.

The advantage of #!/usr/bin/env php is that it will use whatever `php` executable appears first in the user's $PATH.

The disadvantage of #!/usr/bin/env php is that it will use whatever `php` executable appears first in the user's $PATH.

https://unix.stackexchange.com/a/29620