### PR TITLE
Disable some rules which often result in false positives

### DIFF
--- a/fub-standard.ini
+++ b/fub-standard.ini
@@ -29,11 +29,10 @@ multibyte = true
 
 ; PHP tags
 [OpenTagAtBeginningRule]
-[CloseTagAtEndRule]
 
 ; Importing and Dependencies
 [IncludeAndRequireWithoutBracketsRule]
-[NamespaceComesAfterOpeningAndNewlineRule]
+
 [UseNoLeadingBackslashRule]
 [DependencyIsUsedRule]
 
@@ -56,17 +55,13 @@ multibyte = true
 
 ; Classes
 [NoVarKeywordsRule]
-[OneClassPerFileRule]
 [EmptyLineBeforeCloseTagRule]
-[NoEmptyLineBeforeClassCloseRule]
 ; [MethodsMustHaveVisibilityOperatorRule]
-[SingleEmptyLineMustFollowClassDefinitionRule]
 
 ; Documentation
 [FunctionParametersMustBeDocumentedRule]
 ;[DocBlockTagsOrderRule]
 order=link,see,param,return
-[ClassesMustHaveDocBlockRule]
 ; [FunctionsMustHaveDocBlockRule]
 
 ; Considered bad practice
@@ -84,3 +79,23 @@ order=link,see,param,return
 ;[NoVarDumpStatementsRule]
 ; [NoEchoStatementsRule]
 ; [NoInlineHtmlRule]
+
+; ======================================================================
+; Rules we previously had enabled, but are now disabled because:
+; - we want to move toward PSR-2, and the rule conflicts with that
+; - PHPca is 9 years old, and doesn't correctly parse all PHP 7 features
+; ======================================================================
+
+; NOTE: declare(strict_types = 1); and a few other directives need to
+; precede the namespace, so this rule is not useful on our codebase.
+; [NamespaceComesAfterOpeningAndNewlineRule]
+
+; NOTE: The following rules cause false positives whenever
+; "SomeObject::class" syntax is used in a source file.
+; [OneClassPerFileRule]
+; [NoEmptyLineBeforeClassCloseRule]
+; [SingleEmptyLineMustFollowClassDefinitionRule]
+; [ClassesMustHaveDocBlockRule]
+
+; NOTE: Not PSR-2.
+; [CloseTagAtEndRule]


### PR DESCRIPTION
The aim of this PR is to disable rules which often result in false positives.

Ideally, we should replace the things disabled here with a more modern code analyzer and/or code formatter.  Formatting specifically has been discussed at https://3.basecamp.com/3523287/buckets/1668641/messages/1379848698
