### PR TITLE
Escape names before inserting into regex

### DIFF
--- a/lib/phpca/src/Rule/DependencyIsUsedRule.php
+++ b/lib/phpca/src/Rule/DependencyIsUsedRule.php
@@ -36,7 +36,7 @@ class DependencyIsUsedRule extends Rule
                 }
                 $this->file->next();
             }
-            $name = end($parts);
+            $name = preg_quote(end($parts), '/');
 
             $patterns = array(
                 "new {$name}\(",

--- a/lib/phpca/tests/Rule/DependencyIsUsedRule.php
+++ b/lib/phpca/tests/Rule/DependencyIsUsedRule.php
@@ -16,7 +16,7 @@ class DependencyIsUedRuleTest extends AbstractRuleTest
         $this->result->addFile($filename);
     }
 
-	/**
+    /**
      * @covers \spriebsch\PHPca\Rule\DependencyIsUsedRule
      */
     public function testDetect()
@@ -31,7 +31,7 @@ class DependencyIsUedRuleTest extends AbstractRuleTest
         $this->assertEquals(1, $this->result->getNumberOfViolations());
     }
 
-	/**
+    /**
      * @covers \spriebsch\PHPca\Rule\DependencyIsUsedRule
      */
     public function testDetectInstanceof()
@@ -42,11 +42,11 @@ class DependencyIsUedRuleTest extends AbstractRuleTest
 
         $rule->check($this->file, $this->result);
 
-		$this->assertFalse($this->result->hasViolations());
+        $this->assertFalse($this->result->hasViolations());
         $this->assertEquals(0, $this->result->getNumberOfViolations());
     }
 
-	/**
+    /**
      * @covers \spriebsch\PHPca\Rule\DependencyIsUsedRule
      */
     public function testDetectTypeHint()
@@ -57,7 +57,22 @@ class DependencyIsUedRuleTest extends AbstractRuleTest
 
         $rule->check($this->file, $this->result);
 
-		$this->assertFalse($this->result->hasViolations());
+        $this->assertFalse($this->result->hasViolations());
+        $this->assertEquals(0, $this->result->getNumberOfViolations());
+    }
+
+    /**
+     * @covers \spriebsch\PHPca\Rule\DependencyIsUsedRule
+     */
+    public function testDetectBeegTypeHint()
+    {
+        $this->init(__DIR__ . '/../_testdata/DependencyIsUsedRule/Neuronoid.php');
+
+        $rule = new DependencyIsUsedRule();
+
+        $rule->check($this->file, $this->result);
+
+        $this->assertFalse($this->result->hasViolations());
         $this->assertEquals(0, $this->result->getNumberOfViolations());
     }
 }

--- a/lib/phpca/tests/_testdata/DependencyIsUsedRule/Neuronoid.php
+++ b/lib/phpca/tests/_testdata/DependencyIsUsedRule/Neuronoid.php
@@ -1,0 +1,11 @@
+<?php
+
+class Neuronoid
+{
+    public function Synapse(): void
+    {
+        $factory = new Component\Offense\ParticleFactory();
+        $synapseCore = $factory->create();
+        $synapseCore->initialize();
+    }
+}


### PR DESCRIPTION
Hit an issue with a file that had namespaces since they were using backslashes that weren't getting escaped