### PR TITLE
Disable long line checks in syntax check

### DIFF
--- a/fub-standard.ini
+++ b/fub-standard.ini
@@ -20,11 +20,6 @@ additional_rules = rules
 
 ;[NoEolAtEofRule]
 [NoTrailingWhitespaceRule]
-; With multibyte enabled here, requires to have
-; either the `intl` or `mbstring` extension installed.
-[MaximumLineLengthRule]
-line_length = 122
-multibyte = true
 ;[NotExecutableRule]
 
 ; PHP tags
@@ -108,3 +103,11 @@ skip=extensions/command/Misc.php, extensions/command/Leads.php, extensions/comma
 ; which are propertly handled by a try/catch or other means.  This is not
 ; something a modern PHP developer needs to be warning about by the linter.
 ; [NoShutupOperatorsRule]
+
+; NOTE: occassionally it is useful to link to a reference in a comment, which can mean
+; including a long-ish URL which cannot be easily broken up into multiple lines.
+; In general, we nowadays let prettier handle formatting, so this rule isn't needed
+; for most of our PHP source code.
+; [MaximumLineLengthRule]
+; line_length = 122
+; multibyte = true


### PR DESCRIPTION
Problem
=======

Sometimes it useful to reference documentation in code comments, for example when documenting the contents of fields provided by a third-party API or integration.  This can look like:

```php
// - slot_start_sec: Start time of the appointment slot in seconds of UTC time since Unix epoch.
// https://developers.google.com/maps-booking/verticals/local-services/reference/rest-api-v3/bookings/slot-specification
$start = new DateTime('@' . $booking->slot_start_sec);
```

Currently the syntax checker doesn't allow long lines like this, and there is no way to
disable the check for just this line.

Solution
========

Just disable the max line length check -- we don't need it for most files, as most existing files and all new files are processed with prettier, which will take care of the long line formatting where possible.
